### PR TITLE
fix Tongyi Example typo of llms/tongyi.py

### DIFF
--- a/libs/langchain/langchain/llms/tongyi.py
+++ b/libs/langchain/langchain/llms/tongyi.py
@@ -95,7 +95,7 @@ class Tongyi(LLM):
         .. code-block:: python
 
             from langchain.llms import Tongyi
-            Tongyi = tongyi()
+            tongyi = Tongyi()
     """
 
     @property


### PR DESCRIPTION
fix obvious error: Tongyi Example llms/tongyi.py

from langchain.llms import Tongyi
            Tongyi = tongyi()

should be:
            
            from langchain.llms import Tongyi
            tongyi= Tongyi()
